### PR TITLE
Added initial support for SPDK

### DIFF
--- a/linstor/responses.py
+++ b/linstor/responses.py
@@ -361,6 +361,7 @@ class StoragePoolDriver(object):
     SwordfishInitiator = "SWORDFISH_INITIATOR"
     FILE = "FILE"
     FILEThin = "FILE_THIN"
+    SPDK = "SPDK"
 
     @staticmethod
     def list():
@@ -373,7 +374,8 @@ class StoragePoolDriver(object):
             StoragePoolDriver.SwordfishTarget,
             StoragePoolDriver.SwordfishInitiator,
             StoragePoolDriver.FILE,
-            StoragePoolDriver.FILEThin
+            StoragePoolDriver.FILEThin,
+            StoragePoolDriver.SPDK
         ]
 
     @classmethod
@@ -419,9 +421,12 @@ class StoragePoolDriver(object):
                 StoragePoolDriver.FILEThin]:
             return {apiconsts.NAMESPC_STORAGE_DRIVER + '/' + apiconsts.KEY_STOR_POOL_FILE_DIRECTORY: driver_pool_name}
 
+        if storage_driver == StoragePoolDriver.SPDK:
+            return {apiconsts.NAMESPC_STORAGE_DRIVER + '/' + apiconsts.KEY_STOR_POOL_VOLUME_GROUP: driver_pool_name}
+
         raise LinstorError(
             "Unknown storage driver '{drv}', known drivers: "
-            "lvm, lvmthin, zfs, swordfish, diskless".format(drv=storage_driver)
+            "lvm, lvmthin, zfs, swordfish, diskless, spdk".format(drv=storage_driver)
         )
 
     @classmethod
@@ -449,6 +454,9 @@ class StoragePoolDriver(object):
         if storage_driver_enum == StoragePoolDriver.ZFSThin:
             return props.get(apiconsts.NAMESPC_STORAGE_DRIVER + '/' + apiconsts.KEY_STOR_POOL_ZPOOLTHIN, '')
 
+        if storage_driver_enum == StoragePoolDriver.SPDK:
+            return props.get(apiconsts.NAMESPC_STORAGE_DRIVER + '/' + apiconsts.KEY_STOR_POOL_VOLUME_GROUP, '')
+
         return ''
 
 
@@ -460,7 +468,8 @@ class StoragePool(RESTMessageResponse):
         "ZFS": "ZfsDriver",
         "ZFS_THIN": "ZfsThinDriver",
         "SWORDFISH_TARGET": "SwordfishTargetDriver",
-        "SWORDFISH_INITIATOR": "SwordfishInitiatorDriver"
+        "SWORDFISH_INITIATOR": "SwordfishInitiatorDriver",
+        "SPDK": "SpdkDriver"
     }
 
     def __init__(self, rest_data):


### PR DESCRIPTION
This pull request introduces to Linstor a possibility to create a storage pool from SPDK lvol store, construct SPDK lvol bdev and expose it as SPDK nvmf subsystem.

How to start using it:
1. Download and compile [SPDK v19.07](https://github.com/spdk/spdk/releases/tag/v19.07)
2. Setup SPDK
`spdk-19.07/scripts/setup.sh`
3. Start SPDK nvmf_tgt
`spdk-19.07/app/nvmf_tgt/nvmf_tgt`
4. Create SPDK nvme bdev from a drive
`spdk-19.07/scripts/rpc.py construct_nvme_bdev -b NVMe1 -t PCIe -a 0000:3e:00.0`
5. Create SPDK lvol store on the nvme bdev
`spdk-19.07/scripts/rpc.py construct_lvol_store NVMe1n1 sample-lvol-store`
6. Create a symlink to SPDK rpc.py script
`ln -s spdk-19.07/scripts/rpc.py /usr/bin/rpc.py`
7. Start Linstor and create a SPDK storage pool and a resource from it
```
linstor node create sample-node 10.1.0.1 --node-type Combined
linstor storage-pool-definition create spdk-pool
linstor storage-pool create spdk sample-node spdk-pool sample-lvol-store
linstor resource-definition create sample-resource
linstor volume-definition create sample-resource 10G
linstor resource create --layer-list nvme,storage --storage-pool spdk-pool sample-node sample-resource
```