### PR TITLE
linstorapi: remove unused logger

### DIFF
--- a/linstor/linstorapi.py
+++ b/linstor/linstorapi.py
@@ -3,7 +3,6 @@ Linstorapi module
 """
 from __future__ import print_function
 
-import logging
 import socket
 import sys
 import time
@@ -52,8 +51,6 @@ except ImportError:
 API_VERSION_MIN = "1.0.4"
 API_VERSION = API_VERSION_MIN
 
-
-logging.basicConfig(level=logging.WARNING)
 
 
 class ResourceData(object):
@@ -238,7 +235,6 @@ class Linstor(object):
 
     def __init__(self, ctrl_host, timeout=300, keep_alive=False, agent_info=""):
         self._ctrl_host = ctrl_host
-        self._logger = logging.getLogger('Linstor')
         self._timeout = timeout
         self._keep_alive = keep_alive
         self._rest_conn = None  # type: Optional[HTTPConnection]


### PR DESCRIPTION
Hello folks! 

First of all thanks a lot for this client library, we've been finding it very useful. 

We noticed that we had some duplicated logs in our application that makes use of this library. The duplicated logs had a different formatting than the one configured by us and were all emitted with the `WARNING` level. After some testing, we found that this library was setting its log level directly in the Python root logger. These changes in the root logger were then propagated to all other loggers used by our application.

Since this logger wasn't being used anywhere I just removed it. In the case that we actually do want to log something in the library I think we could configure just the logger that was retrieved from the `logging.getLogger` function, which avoids the propagation of those settings to other logs in the user's program.